### PR TITLE
Update buildnpush2iris.sh

### DIFF
--- a/buildnpush2iris.sh
+++ b/buildnpush2iris.sh
@@ -27,7 +27,7 @@ Run()
         exit
     }
 
-    python3.9 setup.py bdist_wheel
+    docker run --rm -it -v "$(pwd):/setup" -w /setup python:3.9 python3.9 setup.py bdist_wheel
 
     latest=$(get_recent_file)
     module=${latest#"./dist/"}


### PR DESCRIPTION
Added docker command to run the setup.
This removes the need for the host system to have python3.9 installed when running IRIS and Cortex with Docker.